### PR TITLE
fix: AIHR end date and theme persistence across routes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,7 +31,7 @@ export default defineNuxtConfig({
   modules: ['@vueuse/nuxt'],
   app: {
     head: {
-      htmlAttrs: { lang: 'en', class: 'dark' },
+      htmlAttrs: { lang: 'en' },
       // Static SEO tags so crawlers that skip SPA JS still get a preview image.
       title: 'Hossein Mousavi — Senior DevOps Engineer',
       meta: [

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -104,7 +104,7 @@ export const experiences: JobExperience[] = [
     companyId: 0,
     employmentType: 'Full-Time',
     startDate: 'February 2025',
-    endDate: 'September 2026',
+    endDate: 'August 2026',
     jobTitle: 'Senior Software Engineer',
     jobSummary:
       'I brought several Angular codebases together into one Nx monorepo and introduced a shared design system and component library. I helped move the team from Bitbucket to GitHub, set up delivery with GitHub Actions and AWS, and shaped frontend architecture practices across projects. I used AI-assisted tools for exploration and refactoring and shipped a new reporting experience for the product.',

--- a/src/plugins/color-mode.client.ts
+++ b/src/plugins/color-mode.client.ts
@@ -3,4 +3,12 @@ export default defineNuxtPlugin(() => {
   if (mode.value === 'auto' || !mode.value) {
     mode.value = 'dark';
   }
+
+  // Keep Unhead's html class in sync with the persisted preference so route
+  // changes (useHead/useSeoMeta) cannot reset the theme back to dark.
+  useHead({
+    htmlAttrs: {
+      class: computed(() => (mode.value === 'dark' ? 'dark' : '')),
+    },
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update AIHR end date from **September 2026** to **August 2026** so it does not overlap NN (which still starts September 2026).
- Fix theme reset on navigation: Unhead was re-applying a hardcoded `html` `class="dark"` from `nuxt.config` whenever page meta updated on route change. The theme class is now driven from the persisted VueUse color mode preference.

## Test plan
- [x] On Experiences, confirm NN shows `September 2026 – Present` and AIHR shows `February 2025 – August 2026`
- [x] Toggle to light mode, navigate Home → Experiences → Blog; theme stays light (desktop and mobile viewport)
- [x] Toggle back to dark and confirm it still persists across routes
- [ ] Hard refresh still respects the last chosen theme (via localStorage)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08bfe-95d9-748c-a8f9-c60d5f719d39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08bfe-95d9-748c-a8f9-c60d5f719d39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

